### PR TITLE
Recreate user profile on breaking changes in iov-core

### DIFF
--- a/src/logic/index.ts
+++ b/src/logic/index.ts
@@ -1,6 +1,6 @@
-export { getAccount, getAccountByName, getAddressByName, keyToAddress, sendTransaction } from "./account";
+export * from "./account";
 export * from "./connection";
 export * from "./db";
 export * from "./faucet";
 export * from "./name";
-export { getMainIdentity, getMainKeyring, getMainWalletAndIdentity, loadOrCreateProfile } from "./profile";
+export * from "./profile";

--- a/src/sequences/index.ts
+++ b/src/sequences/index.ts
@@ -6,9 +6,15 @@ import { ThunkDispatch } from "redux-thunk";
 import { FungibleToken } from "@iov/bcp-types";
 import { ChainId } from "@iov/core";
 
-import { BlockchainSpec, keyToAddress, takeFaucetCredit } from "../logic";
-import { sendTransaction, setName } from "../logic/account";
-import { resolveAddress } from "../logic/name";
+import {
+  BlockchainSpec,
+  keyToAddress,
+  resetProfile,
+  resolveAddress,
+  sendTransaction,
+  setName,
+  takeFaucetCredit,
+} from "../logic";
 import { RootActions, RootState } from "../reducers";
 import { addBlockchainAsyncAction, createSignerAction, getAccountAsyncAction } from "../reducers/blockchain";
 import { fixTypes } from "../reducers/helpers";
@@ -16,6 +22,14 @@ import { createProfileAsyncAction, getIdentityAction } from "../reducers/profile
 import { getProfileDB, requireActiveIdentity, requireConnection, requireSigner } from "../selectors";
 
 type RootThunkDispatch = ThunkDispatch<RootState, any, RootActions>;
+
+export const resetSequence = (password: string) => async (
+  _: RootThunkDispatch,
+  getState: () => RootState,
+) => {
+  const db = getProfileDB(getState());
+  return resetProfile(db, password);
+};
 
 // boot sequence initializes all objects
 // this is a thunk-form of redux-saga


### PR DESCRIPTION
Currently, this dies in boot phase without error messages or way to recover, rendering the app dead.

Since this should only happen pre-release (iov-core plans backwards compatibility of data format from 0.8.0 onwards), we can just re-create to keep using the app for now.

I also add better error handling and reporting throughout the boot phase
