### PR TITLE
Use iov faucet

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -4,5 +4,6 @@
     "bootstrapNodes": ["wss://bov.xerusnet.iov.one/"]
   },
   "defaultPassword": "test-pass",
-  "defaultFaucetUri": "https://iov-faucet.xerusnet.iov.one"
+  "defaultFaucetUri": "https://iov-faucet.xerusnet.iov.one",
+  "faucetToken": "IOV"
 }

--- a/config/production.json
+++ b/config/production.json
@@ -4,5 +4,6 @@
     "bootstrapNodes": ["wss://bov.xerusnet.iov.one/"]
   },
   "defaultPassword": "test-pass",
-  "defaultFaucetUri": "https://iov-faucet.xerusnet.iov.one"
+  "defaultFaucetUri": "https://iov-faucet.xerusnet.iov.one",
+  "faucetToken": "IOV"
 }

--- a/config/test.json
+++ b/config/test.json
@@ -4,5 +4,6 @@
     "bootstrapNodes": ["wss://bov.xerusnet.iov.one/"]
   },
   "defaultPassword": "test-pass",
-  "defaultFaucetUri": "https://iov-faucet.xerusnet.iov.one"
+  "defaultFaucetUri": "https://iov-faucet.xerusnet.iov.one",
+  "faucetToken": "IOV"
 }

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router";
 
-import { ChainId, MultiChainSigner, UserProfile } from "@iov/core";
+import { ChainId, MultiChainSigner, TokenTicker, UserProfile } from "@iov/core";
 
 import { Button } from "../components/subComponents/buttons";
 import { CreateWalletForm } from "../components/templates/forms";
@@ -35,7 +35,7 @@ interface HomeProps extends RouteComponentProps<{}> {
 interface HomeDispatchProps {
   readonly reset: (password: string) => Promise<any>;
   readonly boot: (password: string, blockchains: ReadonlyArray<BlockchainSpec>) => Promise<MultiChainSigner>;
-  readonly drinkFaucet: (facuetUri: string) => Promise<any>;
+  readonly drinkFaucet: (facuetUri: string, ticker: TokenTicker) => Promise<any>;
   readonly setName: (name: string, chainId: ChainId) => Promise<any>;
 }
 
@@ -70,7 +70,7 @@ class Home extends React.Component<HomeProps & HomeDispatchProps, HomeState> {
       history,
     } = this.props;
     if (!account) {
-      await drinkFaucet(config["defaultFaucetUri"]);
+      await drinkFaucet(config["defaultFaucetUri"], config["faucetToken"]);
       this.setState({
         booted: true,
       });
@@ -183,7 +183,7 @@ const mapStateToProps = (state: any, ownProps: HomeProps): HomeProps => ({
 const mapDispatchToProps = (dispatch: any): HomeDispatchProps => ({
   boot: (password: string, blockchains: ReadonlyArray<BlockchainSpec>) =>
     dispatch(bootSequence(password, blockchains)),
-  drinkFaucet: (facuetUri: string) => dispatch(drinkFaucetSequence(facuetUri)),
+  drinkFaucet: (facuetUri: string, ticker: TokenTicker) => dispatch(drinkFaucetSequence(facuetUri, ticker)),
   reset: (password: string) => dispatch(resetSequence(password)),
   setName: (name: string, chainId: ChainId) => dispatch(setNameSequence(name, chainId)),
 });

--- a/src/logic/faucet.ts
+++ b/src/logic/faucet.ts
@@ -6,7 +6,7 @@ import { IovFaucet } from "@iov/faucets";
 // expects full uri (eg. https://faucet.friendnet-slow.iov.one/faucet)
 //
 // TODO: add tests once there is a way to do so in local ci environment (not live testnet)
-export function takeFaucetCredit(uri: string, recipient: Address, ticker?: TokenTicker): Promise<void> {
+export function takeFaucetCredit(uri: string, recipient: Address, ticker: TokenTicker): Promise<void> {
   const bovFaucet = new IovFaucet(uri);
   return bovFaucet.credit(recipient, ticker);
 }

--- a/src/sequences/index.ts
+++ b/src/sequences/index.ts
@@ -4,7 +4,7 @@
 import { ThunkDispatch } from "redux-thunk";
 
 import { Amount } from "@iov/bcp-types";
-import { ChainId, MultiChainSigner } from "@iov/core";
+import { ChainId, MultiChainSigner, TokenTicker } from "@iov/core";
 
 import {
   BlockchainSpec,
@@ -101,14 +101,14 @@ export const bootSequence = (password: string, blockchains: ReadonlyArray<Blockc
   return { accounts, signer };
 };
 
-export const drinkFaucetSequence = (facuetUri: string) => async (
+export const drinkFaucetSequence = (facuetUri: string, ticker: TokenTicker) => async (
   _: RootThunkDispatch,
   getState: () => RootState,
 ) => {
   const identity = requireActiveIdentity(getState());
   // --take a drink from the faucet
   const address = keyToAddress(identity);
-  await takeFaucetCredit(facuetUri, address, undefined);
+  await takeFaucetCredit(facuetUri, address, ticker);
 };
 
 export const setNameSequence = (name: string, chainId: ChainId) => async (


### PR DESCRIPTION
This moves the faucet client from the old golang faucet to the new typescript faucet.

This enables:
* Moving to yaknet (which only has the new faucet)
* Using the faucet in CI tests (to actually go through signup flow)
* Eventually using faucets with other tokens and chains (when they are set up)