### PR TITLE
Fix - Show account with namespace

### DIFF
--- a/src/routes/balance/container/index.tsx
+++ b/src/routes/balance/container/index.tsx
@@ -6,23 +6,26 @@ import Layout from "~/routes/balance/components";
 import { history } from "~/store";
 import selector, { SelectorProps } from "./selector";
 
+export const IOV_NAMESPACE = "*iov";
+
 class Balance extends React.Component<SelectorProps> {
+  public readonly onSendPayment = () => {
+    history.push(PAYMENT_ROUTE);
+  };
+
+  public readonly onReceivePayment = () => {
+    history.push(RECEIVE_FROM_IOV_USER);
+  };
+
   public render(): JSX.Element {
     const { name, tokens } = this.props;
-
-    const onSendPayment = () => {
-      history.push(PAYMENT_ROUTE);
-    };
-
-    const onReceivePayment = () => {
-      history.push(RECEIVE_FROM_IOV_USER);
-    };
+    const iovAddress = `${name}${IOV_NAMESPACE}`;
 
     const renderProps = (phone: boolean) => (
       <Layout
-        onSendPayment={onSendPayment}
-        onReceivePayment={onReceivePayment}
-        name={name}
+        onSendPayment={this.onSendPayment}
+        onReceivePayment={this.onReceivePayment}
+        name={iovAddress}
         tokens={tokens}
         phone={phone}
       />

--- a/src/routes/receiveIov/container/index.tsx
+++ b/src/routes/receiveIov/container/index.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import PageMenu from "~/components/pages/PageMenu";
 import { SuggestionButton } from "~/components/subComponents/buttons";
 import { RECEIVE_FROM_NON_IOV_USER } from "~/routes";
+import { IOV_NAMESPACE } from "~/routes/balance/container";
 import ReceiveIovLayout from "~/routes/receiveIov/components";
 import { history } from "~/store";
 import selector, { SelectorProps } from "./selector";
@@ -13,8 +14,6 @@ const Layout = styled.div`
   justify-content: center;
 `;
 
-const IOV_NAMESPACE = "*iov"
-
 class RecieveIov extends React.Component<SelectorProps> {
   public readonly onReceiveExpernal = () => {
     history.push(RECEIVE_FROM_NON_IOV_USER);
@@ -22,7 +21,7 @@ class RecieveIov extends React.Component<SelectorProps> {
 
   public render(): JSX.Element {
     const { accountName } = this.props;
-    const iovAddress = accountName ? `${accountName}${IOV_NAMESPACE}` : "--"
+    const iovAddress = accountName ? `${accountName}${IOV_NAMESPACE}` : "--";
 
     return (
       <PageMenu phoneFullWidth>


### PR DESCRIPTION
**Description**
This PR fixes the account name on Balance and Receive IOV payment routes showing it with IOV's namespace.

It closes #238 and closes #239 

**BEFORE AND AFTER**
Check [this video](https://drive.google.com/open?id=1Kf6p9mDqjJY0dAgAP6ZvpI6fShyb685U)