### PR TITLE
Bugfix: receive non iov tokens

### DIFF
--- a/src/routes/receiveNonIov/container/selector.ts
+++ b/src/routes/receiveNonIov/container/selector.ts
@@ -20,17 +20,13 @@ export const availableTokensSelector = createSelector(
     if (tickers.length === 0) {
       return [];
     }
-    const tickersByChainAndAddress = accounts
-      .map(acct => ({
-        address: acct.address,
-        tickers: tickers.filter(t => t.chainId === acct.chainId).map(t => t.ticker),
-      }));
-
-    const tickersByAddress = tickersByChainAndAddress.map(acct =>
-      acct.tickers.map(t => ({
-        token: t.tokenTicker,
-        address: acct.address,
-      })),
+    const tickersByAddress = accounts.map(acct =>
+      tickers
+        .filter(t => t.chainId === acct.chainId)
+        .map(t => ({
+          address: acct.address,
+          token: t.ticker.tokenTicker,
+        })),
     );
 
     return tickersByAddress.reduce((acc, cur) => [...acc, ...cur], []);

--- a/src/utils/conf.ts
+++ b/src/utils/conf.ts
@@ -36,11 +36,7 @@ function isArrayOfStrings(array: ReadonlyArray<any>): array is ReadonlyArray<str
 }
 
 export function parseChainConfig(chainConf: any): void {
-  if (
-    !chainConf.chainSpec ||
-    !chainConf.chainSpec.codecType ||
-    !chainConf.chainSpec.bootstrapNodes
-  ) {
+  if (!chainConf.chainSpec || !chainConf.chainSpec.codecType || !chainConf.chainSpec.bootstrapNodes) {
     throw new Error("Missed required property in chain config");
   }
 


### PR DESCRIPTION
It was not working when one of the accounts was undefined (which happens with Lisk in the absence of a faucet in the testnet).

I improved the selector to more properly handle accounts that are undefined, so we can receive even if we have no tokens.