### PR TITLE
Hotfix - Send payment validation form

### DIFF
--- a/src/components/forms/SelectField/index.tsx
+++ b/src/components/forms/SelectField/index.tsx
@@ -73,7 +73,8 @@ class SelectInput extends React.PureComponent<Props, State> {
     } = this.props;
 
     this.setState({ value: value.name }, () => {
-      onChange(value);
+      const tsOnChange: (value: string) => void = onChange
+      tsOnChange(value.name);
       if (onChangeCallback) {
         onChangeCallback(value);
       }


### PR DESCRIPTION
**Description**
This hotfix solves the error pushing an Item to form instead of an expected string value. Added a TS function for avoiding this problem in the future.