### PR TITLE
Feature - Simulating user introduces an incorrect password

### DIFF
--- a/src/routes/login/test/login.dom.spec.ts
+++ b/src/routes/login/test/login.dom.spec.ts
@@ -1,9 +1,12 @@
+import { UserProfile } from "@iov/keycontrol";
 import { Store } from "redux";
+// import * as profile from "~/logic/profile";
 import { mayTestBns } from "~/logic/testhelpers";
 import { RootState } from "~/reducers";
 import { BALANCE_ROUTE, LOGIN_ROUTE, SET_NAME_ROUTE } from "~/routes";
 import { processBalance, travelToBalance } from "~/routes/balance/test/util/travelBalance";
 import { TEST_PASS_PHRASE } from "~/routes/signupPass/test/utils/travelSignup";
+import { getProfileDB } from "~/selectors";
 import { shutdownSequence } from "~/sequences";
 import { aNewStore, resetHistory } from "~/store";
 import { expectRoute } from "~/utils/test/dom";
@@ -45,6 +48,28 @@ describe("DOM > Feature > Login", () => {
 
       await processLogin(loginDom, TEST_PASS_PHRASE);
       expectRoute(refreshStore, BALANCE_ROUTE);
+    },
+    30000,
+  );
+
+  mayTestBns(
+    `should fail if user introduces incorrect password`,
+    async () => {
+      // GIVEN
+      const loginDom = await travelToBalance(refreshStore);
+      const db = getProfileDB(refreshStore.getState());
+      const wrongPassword = "wrong password";
+      const loadProfileSpy = jest.spyOn(UserProfile, "loadFrom");
+
+      // WHEN
+      expectRoute(refreshStore, LOGIN_ROUTE);
+      await processLogin(loginDom, wrongPassword);
+
+      // THEN
+      expect(loadProfileSpy).toHaveBeenCalledTimes(1);
+      expect(loadProfileSpy).toHaveBeenLastCalledWith(db, wrongPassword);
+      await expect(UserProfile.loadFrom(db, wrongPassword)).rejects.toThrow("invalid usage");
+      expectRoute(refreshStore, LOGIN_ROUTE);
     },
     30000,
   );


### PR DESCRIPTION
**Description**
The aim of this PR besides add a common use case of the app is:
* Introduce JEST spyOn mock function in place
* Test correctly async/await reject responses via Error
* Introduce the GIVEN | WHEN | THEN philosophy of testing.

**Note for developers**
Take a look into the code and match with the list created above.

**Documentation**
- https://jestjs.io/docs/en/tutorial-async
- https://medium.com/@rickhanlonii/understanding-jest-mocks-f0046c68e53c 