### PR TITLE
Hotfix - #305 - Fix max decimals when sending payment

### DIFF
--- a/src/routes/sendPayment/components/FillPayment/SendCard.tsx
+++ b/src/routes/sendPayment/components/FillPayment/SendCard.tsx
@@ -7,6 +7,7 @@ import {
   composeValidators,
   greaterThanOrEqual,
   lowerThanOrEqual,
+  maxDecimals,
   mustBeFloat,
   required,
 } from "~/components/forms/validator";
@@ -98,6 +99,7 @@ class SendCard extends React.Component<Props, State> {
                 validate={composeValidators(
                   required,
                   mustBeFloat,
+                  maxDecimals(fractionalDigits),
                   greaterThanOrEqual(0.000000001),
                   lowerThanOrEqual(crypto),
                 )}

--- a/src/routes/sendPayment/container/index.tsx
+++ b/src/routes/sendPayment/container/index.tsx
@@ -123,7 +123,6 @@ export class SendPaymentInternal extends React.Component<Props, State> {
     if (!accountName) {
       throw new Error("Not possible to send a transaction without an account");
     }
-    // we start the sequence, but do not
     sendTransaction(chainId, recipient, paddedTxAmount, note, id, accountName);
 
     history.push(BALANCE_ROUTE);


### PR DESCRIPTION
**Description**
In this PR we fix the problem when entering more decimals than allowed. Before the code throw one exception, it was expected, but the UI should notify the user, instead of breaking `sendTransaction` sequence.

It closes #305 